### PR TITLE
Fix configuration files ownership

### DIFF
--- a/resources/pdns_authoritative_config.rb
+++ b/resources/pdns_authoritative_config.rb
@@ -70,7 +70,7 @@ action :create do
   end
 
   directory new_resource.socket_dir do
-    owner new_resource.run_user
+    owner 'root'
     group new_resource.run_group
     # Because of the DynListener creation before dropping privileges, the
     # socket-directory has to be '0777' for now
@@ -84,7 +84,7 @@ action :create do
     source new_resource.source
     cookbook new_resource.cookbook
     owner 'root'
-    group 'root'
+    group new_resource.run_group
     mode '0640'
     variables(
       launch: new_resource.launch,

--- a/resources/pdns_recursor_config.rb
+++ b/resources/pdns_recursor_config.rb
@@ -70,7 +70,7 @@ action :create do
   end
 
   directory new_resource.socket_dir do
-    owner new_resource.run_user
+    owner 'root'
     group new_resource.run_group
     # When using service_manager the 'socket-dir' has to be writable for the 'set-gid'
     # in order to start the service:
@@ -84,7 +84,7 @@ action :create do
     source new_resource.source
     cookbook new_resource.cookbook
     owner 'root'
-    group 'root'
+    group new_resource.run_group
     mode '0640'
     variables(
       socket_dir: new_resource.socket_dir,


### PR DESCRIPTION
The config files must be readable by the pdns server & recursor, it is even more important now that recent RPMs enforce the default service user to pdns & pdns-recursor respectively.