### PR TITLE
Do not create socket-dir in config resource

### DIFF
--- a/resources/pdns_authoritative_config.rb
+++ b/resources/pdns_authoritative_config.rb
@@ -69,17 +69,6 @@ action :create do
     action :create
   end
 
-  directory new_resource.socket_dir do
-    owner 'root'
-    group new_resource.run_group
-    # Because of the DynListener creation before dropping privileges, the
-    # socket-directory has to be '0777' for now
-    # Issue: https://github.com/PowerDNS/pdns/issues/4826
-    mode Chef::Platform::ServiceHelpers.service_resource_providers.include?(:systemd) ? '0777' : '0755'
-    recursive true
-    action :create
-  end
-
   template "#{new_resource.config_dir}/pdns-#{new_resource.instance_name}.conf" do
     source new_resource.source
     cookbook new_resource.cookbook

--- a/resources/pdns_recursor_config.rb
+++ b/resources/pdns_recursor_config.rb
@@ -69,17 +69,6 @@ action :create do
     action :create
   end
 
-  directory new_resource.socket_dir do
-    owner 'root'
-    group new_resource.run_group
-    # When using service_manager the 'socket-dir' has to be writable for the 'set-gid'
-    # in order to start the service:
-    # Issue: https://github.com/PowerDNS/pdns/issues/4826
-    mode '0775'
-    recursive true
-    action :create
-  end
-
   template "#{new_resource.config_dir}/recursor-#{new_resource.instance_name}.conf" do
     source new_resource.source
     cookbook new_resource.cookbook


### PR DESCRIPTION
Creating socket dir in advance prevents us from upgrading
pdns because the runtime directory (aka socket dir) is
created by systemd via RuntimeDirectory pararemeter. And
if the directory already exists, systemd fails to start pdns.

As this is quite old, if we still need to create it for servers
not migrated yet, then it will be temporarily done just after
pdns_(authoritative|recursor)_config.